### PR TITLE
Remove `ios/` and `android/` from `.gitignore`

### DIFF
--- a/.changeset/nasty-poets-attack.md
+++ b/.changeset/nasty-poets-attack.md
@@ -1,0 +1,5 @@
+---
+'capkit': patch
+---
+
+remove ios/ and android/ from .gitignore

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -178,7 +178,7 @@ export async function initializeProject({ appName, appId, platforms, plugins }: 
 			start: `Configuring: "${kleur.cyan('.gitignore')}"`,
 			stop: `Successfully configured: "${kleur.cyan('.gitignore')}"`,
 			task: async () => {
-				const lines = ['# Capacitor', '/android', '/ios', 'capacitor.config.json.timestamp-*'];
+				const lines = ['# Capacitor', 'capacitor.config.json.timestamp-*'];
 				const gitignore = await fs.readFile(`${process.cwd()}/.gitignore`, 'utf-8');
 				const uniqueLines = lines.filter((line) => !gitignore.includes(line));
 				if (uniqueLines.length === 0) return;


### PR DESCRIPTION
closes #69 